### PR TITLE
Documentation and spelling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-    "julia.environmentPath": "/Users/johnbuckner/.julia/environments/v1.7"
 }

--- a/docs/src/Models.md
+++ b/docs/src/Models.md
@@ -133,12 +133,12 @@ UniversalDiffEq.CustomDifference(data,step,initial_parameters;kwrags...)
 
 Covariates can also be added to UDE models by passing a data frame `X` and adding covariates as an argument to the `derivs!` function which has the new form `derivs!(du,u,X,p,t)`, where the third argument `X` is a vector of covariates. 
 ```@docs
-UniversalDiffEq.CustomDerivatives(data::DataFrame,X::DataFrame,derivs!::Function,initial_parameters;kwargs ... )
+UniversalDiffEq.CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;kwargs ... )
 ```
 
 Covariates can also be added to a discrete time framework in the same way. The `step` function should have four arguments `step(u,X,t,p)`.
 ```@docs
-UniversalDiffEq.CustomDifference(data::DataFrame,X::DataFrame,step,initial_parameters;kwargs ... )
+UniversalDiffEq.CustomDifference(data::DataFrame,X,step,initial_parameters;kwargs ... )
 ```
 ### Example
 

--- a/src/HierarchicalUDE.jl
+++ b/src/HierarchicalUDE.jl
@@ -133,7 +133,7 @@ function get_series_info(data,nlevels)
 end 
 
 
-function initialize_state_estiamtes(data,dims)
+function initialize_state_estimates(data,dims)
     dims = size(data)[2]-2
     uhat = zeros(size(data)[1],dims)
     return uhat

--- a/src/ModelTesting.jl
+++ b/src/ModelTesting.jl
@@ -8,7 +8,7 @@ end
 """
     plot_state_estimates(UDE::UDE)
 
-Plots the value of the state variables estiamted by the UDE model. 
+Plots the value of the state variables estimated by the UDE model. 
 """
 function plot_state_estimates(UDE::UDE)
     
@@ -31,7 +31,7 @@ end
 """
     print_parameter_estimates(UDE::UDE)
 
-prints the value of the known dynamcis paramters. 
+prints the value of the known dynamcis parameters. 
 """
 function print_parameter_estimates(UDE::UDE)
     println("Estimated parameter values: ")
@@ -70,7 +70,7 @@ end
 """
     get_right_hand_side(UDE::UDE)
 
-Returns the right hand side of the differntial equation (or difference equaiton) used to build the process model.
+Returns the right hand side of the differential equation (or difference equation) used to build the process model.
 
 The fuction will take the state vector `u` and time `t` if the model does not include covariates. If covaraites are included the arguments are the state vector `u` , covariates vector `x`, and time `t`
 """
@@ -257,7 +257,7 @@ end
 """
     plot_forecast(UDE::UDE, T::Int)
 
-Plots the models forecast up to T time steps into the future from the last observaiton.  
+Plots the models forecast up to T time steps into the future from the last observation.  
 """
 function plot_forecast(UDE::UDE, T::Int)
     u0 = UDE.parameters.uhat[:,end]
@@ -454,7 +454,7 @@ end
 """
     leave_future_out_cv(model; forecast_length = 10,  K = 10, spacing = 1, step_size = 0.05, maxiter = 500)
     
-Runs K fold leave future out cross validation and returns the mean squared forecasting error and a plot to visulaize the model fits.
+Runs K fold leave future out cross validation and returns the mean squared forecasting error and a plot to visualize the model fits.
 
 ...
 # Arguments 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -133,7 +133,7 @@ end
     
 
 """
-    CustomDerivatives(data::DataFrame,X::DataFrame,derivs!::Function,initial_parameters;kwargs ... )
+    CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;kwargs ... )
 
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
 
@@ -172,18 +172,7 @@ function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameter
 
 end
 
-"""
-    CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;kwargs...)
 
-When a function priors is supplied its value will be added to the loss function as a penalty term for user specified paramters. It should take the a single NamedTuple `p` as an argument penelties for each paramter should be calcualted by accessing `p` with the period operator.
-    
-The prior function can be used to nudge the fitted model toward prior expectations for a parameter value. For example, the following function increases the loss when a parameter `p.r` has a value other than 1.5, nad a second parameter `p.beta` is greater than zeros. 
-        
-
-When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
-
-When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the coarates at time `t`.
-"""
 function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     # convert data
     N, dims, T, times, data, dataframe = process_data(data)
@@ -305,7 +294,7 @@ function CustomDifference(data::DataFrame,step,initial_parameters,priors::Functi
 end
 
 """
-    CustomDifference(data::DataFrame,X::DataFrame,step,initial_parameters;kwargs ... )
+    CustomDifference(data::DataFrame,X,step,initial_parameters;kwargs ... )
 
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
 
@@ -344,15 +333,7 @@ function CustomDifference(data::DataFrame,X,step,initial_parameters;proc_weight=
     
 end
 
-"""
-    CustomDifference(data::DataFrame,X,step,initial_parameters,priors::Function;kwargs...)
 
- When a function priors is supplied its value will be added to the loss function as a penalty term for user specified paramters. It should take the a single NamedTuple `p` as an argument penelties for each paramter should be calcualted by accessing `p` with the period operator. 
-
-When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
-
-When `X` is provided the step function must have the form `step(u,x,t,p)` where `x` is a vector with the value of the covariates at time `t`. 
-"""
 function CustomDifference(data::DataFrame,X,step,initial_parameters,priors::Function;proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
     
     # convert data

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -8,13 +8,13 @@ Basic data structure used to the model structure, parameters and data for UDE an
 - times: a vector of times for each observation
 - data: a matrix of observaitons at each time point
 - X: a DataFrame with any covariates used by the model
-- data_frame: a DataFrame with colums for the time of each observation and values of the state variables
+- data_frame: a DataFrame with columns for the time of each observation and values of the state variables
 - parameters: a ComponentArray that stores model parameters
 - loss_function: the loss function used to fit the model
 - process_model: a Julia mutable struct used to define model predictions 
-- process_loss: a Julia mutable struct used to measure the peroance of model predictions
-- observation_model: a Julia mutable struct used to predict observaitons given state variable estiamtes
-- observaiton_loss: a Julia mutable struct used to measure the performance of the observaiton model
+- process_loss: a Julia mutable struct used to measure the performance of model predictions
+- observation_model: a Julia mutable struct used to predict observaitons given state variable estimates
+- observaiton_loss: a Julia mutable struct used to measure the performance of the observation model
 - process_regularization: a Julia mutable struct used to store data needed for process model regularization
 - observation_regularization: a Julia mutable struct used to store data needed for observation model regularization
 - constructor: A function that initializes a UDE model with identical structure. 
@@ -40,13 +40,13 @@ end
 """
     CustomDerivatives(data,derivs!,initial_parameters;kwargs ... )
 
-Constructs a UDE model for the data set `data`  based on user defined derivitives `derivs`. An initial guess of model parameters are supplied with the `initial_parameters` argument. 
+Constructs a UDE model for the data set `data`  based on user defined derivatives `derivs`. An initial guess of model parameters are supplied with the `initial_parameters` argument. 
 
 ...
 # Arguments
 
 - data: a DataFrame object with the time of observations in a column labeled `t` and the remaining columns the value of the state variables at each time point. 
-- derivs: a Function of the form `derivs!(du,u,p,t)` where `u` is the value of the state variables, `p` are the model parameters, `t` is time, and du is updated with the value of the derivitives
+- derivs: a Function of the form `derivs!(du,u,p,t)` where `u` is the value of the state variables, `p` are the model parameters, `t` is time, and du is updated with the value of the derivatives
 - init_parameters: A `NamedTuple` with the model parameters. Neural network parameters must be listed under the key `NN`.
 ...
 """
@@ -89,7 +89,7 @@ end
 """
     CustomDerivatives(data::DataFrame,derivs!::Function,initial_parameters,priors::Function;kwargs ... )
 
-When a function priors is supplied its value will be added to the loss function as a penalty term for user specified paramters. It should take the a single NamedTuple `p` as an argument penelties for each paramter should be calcualted by accessing `p` with the period operator.
+When a function's priors is supplied its value will be added to the loss function as a penalty term for user specified parameters. It should take the a single NamedTuple `p` as an argument penalties for each paramter should be calculated by accessing `p` with the period operator.
     
 The prior function can be used to nudge the fitted model toward prior expectations for a parameter value. For example, the following function increases the loss when a parameter `p.r` has a value other than 1.5, nad a second parameter `p.beta` is greater than zeros. 
 
@@ -135,9 +135,9 @@ end
 """
     CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;kwargs ... )
 
-When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
+When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included in the data frame. 
 
-When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the coarates at time `t`. 
+When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the covariates at time `t`. 
 """
 function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     
@@ -251,7 +251,7 @@ end
 """
     CustomDifference(data::DataFrame,step,initial_parameters,priors::Function;kwargs ... )
 
-When a function priors is supplied its value will be added to the loss function as a penalty term for user specified paramters. It should take the a single NamedTuple `p` as an argument penelties for each paramter should be calcualted by accessing `p` with the period operator. 
+When a function's priors is supplied its value will be added to the loss function as a penalty term for user specified paramters. It should take the a single NamedTuple `p` as an argument penalties for each parameter should be calcualted by accessing `p` with the period operator. 
 
 ```julia 
 function priors(p)
@@ -296,9 +296,9 @@ end
 """
     CustomDifference(data::DataFrame,X,step,initial_parameters;kwargs ... )
 
-When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the vlaue fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included int he data frame. 
+When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included in the data frame. 
 
-When `X` is provided the step function must have the form `step(u,x,t,p)` where `x` is a vector with the value of the coarates at time `t`. 
+When `X` is provided the step function must have the form `step(u,x,t,p)` where `x` is a vector with the value of the covariates at time `t`. 
 """
 function CustomDifference(data::DataFrame,X,step,initial_parameters;proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
     
@@ -372,7 +372,7 @@ end
 """
     NNDE(data;kwargs ...)
 
-Constructs a nonparametric discrete time model for the data set `data` using a single layer neural network to reporesent the systems dynamics. 
+Constructs a nonparametric discrete time model for the data set `data` using a single layer neural network to represent the systems dynamics. 
 """
 function NNDE(data;hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25)
     
@@ -407,7 +407,7 @@ end
 """
     DiscreteUDE(data,step,init_parameters;kwargs ...)
 
-Constructs an additive `UDE` model with user supplied difference equations `step` and a single layer neural network. When `init_parameters` are provided for the use supplied function their values will be estiated in the training process.  
+Constructs an additive `UDE` model with user supplied difference equations `step` and a single layer neural network. When `init_parameters` are provided for the user supplied function their values will be estimated in the training process.  
 
 # Model equaitons
 ```math
@@ -417,11 +417,11 @@ x_{t+1} = f(x_t;\theta) + NN(x_t;w,b)
 ...
 # Key word arguments
 
-- proc_weight=1.0 : Weight given to the model predictiosn in loss funciton
-- obs_weight=1.0 : Weight given to the state estiamtes in loss function 
+- proc_weight=1.0 : Weight given to the model predictions in loss funciton
+- obs_weight=1.0 : Weight given to the state estimates in loss function 
 - reg_weight=10^-6 : Weight given to regularization in the loss function 
-- extrap_rho=0.0 : Asymthotic value of derivitives when extrapolating (negative when extrapolating higher than past observaitons, postive when extrapolating lower)
-- l=0.25 : rate at which extrapolations converge on asymthotic behavior
+- extrap_rho=0.0 : Asymptotic value of derivatives when extrapolating (negative when extrapolating higher than past observations, positive when extrapolating lower)
+- l=0.25 : rate at which extrapolations converge on asymptotic behavior
 ...
 """
 function DiscreteUDE(data,step,init_parameters;
@@ -512,7 +512,7 @@ end
 """
     NODE(data,X;kwargs ... )
 
-When a dataframe `X` is supplied the model will run with covariates. the argumetn `X` should have a column for time `t` with the value fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included in the data frame. 
+When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for values of time not included in the data frame. 
 
 """
 function NODE(data,X;hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0 )

--- a/src/MultipleTimeSeries.jl
+++ b/src/MultipleTimeSeries.jl
@@ -120,7 +120,7 @@ end
 """
     MultiNODE(data;kwargs...)
 
-builds a NODE model to fit to the data. `data` is a DatFrame object with time arguments placed in a colum labed `t` and a second colum with a unique index for each time series. The remaining columns have observation of the state variables at each point in time and for each time series.
+builds a NODE model to fit to the data. `data` is a DataFrame object with time arguments placed in a column labed `t` and a second column with a unique index for each time series. The remaining columns have observations of the state variables at each point in time and for each time series.
 """
 function MultiNODE(data;hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,reg_type="L2",l=0.5,extrap_rho=0.0)
     
@@ -162,7 +162,7 @@ end
 """
     MultiNODE(data,X;kwargs...)
 
-When a dataframe `X` is supplied the model will run with covariates. the argumetn `X` should have a column for time `t` with the value fo time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included in the data frame. 
+When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for values of time not included in the data frame. 
 """
 function MultiNODE(data,X;hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,reg_type="L2",l=0.5,extrap_rho=0.0)
 

--- a/src/ODEAnalysis.jl
+++ b/src/ODEAnalysis.jl
@@ -223,7 +223,7 @@ Attempts to find all the equilibirum points for the UDE model between the upper 
 # kwargs
 - t = 0: The point in time where the UDE model is evaluated, only relevant for time aware UDEs.
 - Ntrials = 100: the number of initializations of the root finding algorithm. 
-- tol = 10^-3: The threshold euclidean distance between point beyond which a new equilbirum is sufficently differnt to be retained. 
+- tol = 10^-3: The threshold euclidean distance between point beyond which a new equilbirum is sufficently different to be retained. 
 ...
 """
 function equilibrium_and_stability(UDE,lower,upper;t=0,Ntrials=100,tol=10^-3)
@@ -287,7 +287,7 @@ Attempts to find all the equilibirum points for the UDE model between the upper 
 # kwargs
 - t = 0: The point in time where the UDE model is evaluated, only relevant for time aware UDEs.
 - Ntrials = 100: the number of initializations of the root finding algorithm. 
-- tol = 10^-3: The threshold euclidean distance between point beyond which a new equilbirum is sufficently differnt to be retained. 
+- tol = 10^-3: The threshold euclidean distance between point beyond which a new equilbirum is sufficently different to be retained. 
 ...
 """
 function equilibrium_and_stability(UDE,X,lower,upper;t=0,Ntrials=100,tol=10^-3,tol2 = 10^-6)

--- a/src/ProcessModels.jl
+++ b/src/ProcessModels.jl
@@ -32,7 +32,7 @@ A Julia mutable struct that stores the functions and parameters for the process 
 # Elements
 - parameters: ComponentArray
 - predict: Function the predict one time step ahead
-- forecast: Function, a modified version of rpedict to imporve performace when extrapolating
+- forecast: Function, a modified version of predict to improve performance when extrapolating
 - covariates: Function that returns the value of the covariates at each point in time. 
 ...
 """

--- a/src/forecasting.jl
+++ b/src/forecasting.jl
@@ -42,9 +42,9 @@ end
 """
     forecast_with_errors(UDE,x0,t0,T,N)
 
-Makes N forcast length dt*T using the model UDE where dt is the average interval between observations in the training data. 
+Makes N forcasts length dt*T using the model UDE where dt is the average interval between observations in the training data. 
 
-The forecast are made by making a deterministic forecasts of length dt. A noise term is added to the prediction by sampling from the process model residuals. The initial condition for each forecast is sampled by sampling a residual from the observaiton model and adding it to the initial dat point `x0`. 
+The forecasts are made by making a deterministic forecast of length dt. A noise term is added to the prediction by sampling from the process model residuals. The initial condition for each forecast is sampled by sampling a residual from the observaiton model and adding it to the initial data point `x0`. 
 """
 function forecast_with_errors(UDE,x0,t0,T,N)
     uhats = UDE.parameters.uhat


### PR DESCRIPTION
Should fix documenter errors from previous commits and also includes corrected spelling for docstrings