### PR TITLE
51 change covariates input data to long format tables

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -174,11 +174,11 @@ When a dataframe `X` is supplied the model will run with covariates. the argumen
 
 When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the covariates at time `t`. 
 """
-function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
+function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = ContinuousProcessModel(derivs!,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)
@@ -208,10 +208,10 @@ function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameter
 end
 
 
-function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
+function CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = ContinuousProcessModel(derivs!,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)
@@ -335,11 +335,11 @@ When a dataframe `X` is supplied the model will run with covariates. the argumen
 
 When `X` is provided the step function must have the form `step(u,x,t,p)` where `x` is a vector with the value of the covariates at time `t`. 
 """
-function CustomDifference(data::DataFrame,X,step,initial_parameters;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
+function CustomDifference(data::DataFrame,X,step,initial_parameters;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = DiscreteProcessModel(step,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)
@@ -369,11 +369,11 @@ function CustomDifference(data::DataFrame,X,step,initial_parameters;time_column_
 end
 
 
-function CustomDifference(data::DataFrame,X,step,initial_parameters,priors::Function;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
+function CustomDifference(data::DataFrame,X,step,initial_parameters,priors::Function;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,extrap_rho = 0.1,l = 0.25,reg_type = "L2")
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = DiscreteProcessModel(step,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)
@@ -484,11 +484,11 @@ end
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for values of time not included in the data frame. 
 
 """
-function NODE(data,X;time_column_name = "time",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0 )
+function NODE(data,X;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0 )
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # submodels
     process_model = NODE_process(dims,hidden_units,covariates,seed,l,extrap_rho)
@@ -558,11 +558,11 @@ end
     EasyNODE(data,X;kwargs ... )
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for values of time not included in the data frame. 
 """
-function EasyNODE(data,X;time_column_name = "time",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0, step_size = 0.05, maxiter = 500, verbose = false)
+function EasyNODE(data,X;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0, step_size = 0.05, maxiter = 500, verbose = false)
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
     # submodels
     process_model = NODE_process(dims,hidden_units,covariates,seed,l,extrap_rho)
     process_loss = ProcessMSE(N,T,proc_weight)
@@ -594,7 +594,7 @@ end
     EasyUDE(data,derivs!,initial_parameters;kwargs ... )
 Constructs a pretrained UDE model for the data set `data`  based on user defined derivatives `derivs`. An initial guess of model parameters are supplied with the `initial_parameters` argument. 
 """
-function EasyUDE(data,known_dynamics!,initial_parameters;time_column_name = "time",hidden_units = 10, seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2", step_size = 0.05, maxiter = 500, verbose = false)
+function EasyUDE(data,known_dynamics!,initial_parameters;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",hidden_units = 10, seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2", step_size = 0.05, maxiter = 500, verbose = false)
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
@@ -644,11 +644,11 @@ end
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for value of time not included in the data frame. 
 When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the covariates at time `t`. 
 """
-function EasyUDE(data::DataFrame,X,known_dynamics!::Function,initial_parameters;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
+function EasyUDE(data::DataFrame,X,known_dynamics!::Function,initial_parameters;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
     # generate submodels 
     NN = Lux.Chain(Lux.Dense(dims+length(covariates(0)),hidden,tanh), Lux.Dense(hidden,dims))
     Random.seed!(seed)  # set seed for reproducibility 
@@ -727,11 +727,11 @@ end
 When a dataframe `X` is supplied the model will run with covariates. the argument `X` should have a column for time `t` with the value for time in the remaining columns. The values in `X` will be interpolated with a linear spline for values of time not included in the data frame. 
 
 """
-function BayesianNODE(data,X;time_column_name = "time",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0 )
+function BayesianNODE(data,X;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6, reg_type = "L2", l = 0.25,extrap_rho = 0.0 )
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # submodels
     process_model = NODE_process(dims,hidden_units,covariates,seed,l,extrap_rho)
@@ -866,11 +866,11 @@ When a dataframe `X` is supplied the model will run with covariates. the argumen
 
 When `X` is provided the derivs function must have the form `derivs!(du,u,x,p,t)` where `x` is a vector with the value of the covariates at time `t`. 
 """
-function BayesianCustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
+function BayesianCustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = ContinuousProcessModel(derivs!,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)
@@ -902,10 +902,10 @@ function BayesianCustomDerivatives(data::DataFrame,X,derivs!::Function,initial_p
 end
 
 
-function BayesianCustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;time_column_name = "time",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
+function BayesianCustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters,priors::Function;time_column_name = "time",variable_column_name = "variable",value_column_name = "value",proc_weight=1.0,obs_weight=1.0,reg_weight=10^-6,extrap_rho=0.1,l=0.25,reg_type = "L2")
     # convert data
     N, dims, T, times, data, dataframe = process_data(data,time_column_name)
-    covariates = interpolate_covariates(X,time_column_name)
+    covariates, vars = interpolate_covariates(X,time_column_name,variable_column_name,value_column_name)
 
     # generate submodels 
     process_model = ContinuousProcessModel(derivs!,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)

--- a/src/MultipleTimeSeries.jl
+++ b/src/MultipleTimeSeries.jl
@@ -180,7 +180,7 @@ When a dataframe `X` is supplied the model will run with covariates. the argumen
 function MultiNODE(data,X;time_column_name = "time", series_column_name = "series", variable_column_name = "variable", value_column_name = "value",hidden_units=10,seed = 1,proc_weight=1.0,obs_weight=1.0,reg_weight = 10^-6,reg_type="L2",l=0.5,extrap_rho=0.0)
 
     N, T, dims, data, times,  dataframe, series, inds, starts, lengths,varnames, labels_df = process_multi_data(data, time_column_name, series_column_name)
-    covariates, variables = interpolate_covariates(data, time_column_name, series_column_name,  variable_column_name, value_column_name)
+    covariates, variables = interpolate_covariates(X, time_column_name, series_column_name,  variable_column_name, value_column_name)
 
 
     process_model = MultiNODE_process(dims,hidden_units,covariates,seed,l,extrap_rho)
@@ -248,7 +248,7 @@ function MultiCustomDerivatives(data,X,derivs!,initial_parameters;time_column_na
     
     # convert data
     N, T, dims, data, times,  dataframe, series, inds, starts, lengths, varnames, labels_df = process_multi_data(data, time_column_name, series_column_name)
-    covariates, variables = interpolate_covariates(data, time_column_name, series_column_name,  variable_column_name, value_column_name)
+    covariates, variables = interpolate_covariates(X, time_column_name, series_column_name,  variable_column_name, value_column_name)
 
     # generate submodels 
     process_model = MultiContinuousProcessModel(derivs!,ComponentArray(initial_parameters),covariates,dims,l,extrap_rho)

--- a/src/covariates.jl
+++ b/src/covariates.jl
@@ -1,48 +1,51 @@
 
-
-function interpolate_covariates(X::DataFrame,time_column_name)
-    N, dims, T, times, data, dataframe = process_data(X,time_column_name)
-    interpolations = [linear_interpolation(times, data[i,:],extrapolation_bc = Interpolations.Flat()) for i in 1:dims]
-    function covariates(t)
-        return [interpolation(t) for interpolation in interpolations]
-    end 
-    return covariates
-end 
-
-
-function interpolate_covariates(X::AbstractVector{},time_column_name)
-
-    interpolations = []
-    for i in eachindex(X)
-        N, dims, T, times, data, dataframe = process_data(X[i],time_column_name)
-        push!(interpolations, linear_interpolation(times, data[1,:],extrapolation_bc = Interpolations.Flat()))
+function process_long_format_data(data, time_column_name, variable_column_name, value_column_name)
+    variables = unique(data[:,variable_column_name])
+    times = []; values = []
+    for var in variables
+        inds = data[:,variable_column_name] .== var
+        dat_i = data[inds,:]
+        push!(times, dat_i[:,time_column_name])
+        push!(values, dat_i[:,value_column_name])
     end
+    return times, values, variables
+end 
 
+function interpolate_covariates(X::DataFrame, time_column_name, variable_column_name, value_column_name)
+    times, values, variables = process_long_format_data(X,time_column_name, variable_column_name,value_column_name)
+    interpolations = [linear_interpolation(times[i], values[i],extrapolation_bc = Interpolations.Flat()) for i in eachindex(times)]
     function covariates(t)
         return [interpolation(t) for interpolation in interpolations]
     end 
-
-    return covariates
+    return covariates, variables
 end 
 
 
+function process_long_format_data(data, time_column_name, series_column_name,  variable_column_name, value_column_name)
+    variables = unique(data[:,variable_column_name])
+    series = unique(data[:,series_column_name])
+    times = []; values = []
+    for series_i in series 
+        times_var = [], values_var = []
+        for var in variables
+            inds = (data[:,variable_column_name] .== var) .& (data[:,series_column_name] .== series_i) 
+            dat_i = data[inds,:]
+            push!(times_var, dat_i[:,time_column_name])
+            push!(values_var, dat_i[:,value_column_name])
+        end
+        push!(times, times_var)
+        push!(values, values_var)
+    end
+    return times, values, variables
+end 
 
-function interpolate_covariates_multi(X,time_column_name,series_column_name)
-    data_sets, times = process_multi_data2(X,time_column_name,series_column_name)
-    dims = size(data_sets[1])[1]
-    interpolations = [[linear_interpolation(times[j], data_sets[j][i,:],extrapolation_bc = Interpolations.Flat()) for i in 1:dims] for j in eachindex(times)]
+
+function interpolate_covariates(data, time_column_name, series_column_name,  variable_column_name, value_column_name)
+    times, values, variables = process_long_format_data(data, time_column_name, series_column_name,  variable_column_name, value_column_name)
+    interpolations = [[linear_interpolation(times[j][i], values[j][i],extrapolation_bc = Interpolations.Flat()) for i in eachindex(times[j])] for j in eachindex(times)]
     function covariates(t,series)
         return [interpolation(t) for interpolation in interpolations[round(Int,series)]]
     end 
     return covariates
 end 
 
-
-function plot_covariates(model)
-    dims = length(model.process_model.covariates(0))
-    plt = plot(model.times,broadcast(t -> model.process_model.covariates(t)[1],model.times), xlabel = "Time", ylabel = "X", label = "")
-    for i in 2:dims
-        plot!(plt,model.times,broadcast(t -> model.process_model.covariates(t)[i],model.times), label = "")
-    end 
-    return plt
-end 

--- a/src/covariates.jl
+++ b/src/covariates.jl
@@ -26,7 +26,7 @@ function process_long_format_data(data, time_column_name, series_column_name,  v
     series = unique(data[:,series_column_name])
     times = []; values = []
     for series_i in series 
-        times_var = [], values_var = []
+        times_var = []; values_var = []
         for var in variables
             inds = (data[:,variable_column_name] .== var) .& (data[:,series_column_name] .== series_i) 
             dat_i = data[inds,:]
@@ -46,6 +46,6 @@ function interpolate_covariates(data, time_column_name, series_column_name,  var
     function covariates(t,series)
         return [interpolation(t) for interpolation in interpolations[round(Int,series)]]
     end 
-    return covariates
+    return covariates, variables
 end 
 


### PR DESCRIPTION
Change the covariates data to long format tables to converge existing code based on wide format tables you can use the RCall library 
`
using RCall
@rput X
R"""
X <- reshape2::melt(X, id.var = c("time","series"))
"""
@rget X
`