### PR TITLE
Changed API page to use autodocs and all other docs blocks to canonical=false

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,8 +1,9 @@
 # API
 
-```@index
-
+```@autodocs
+Modules = [UniversalDiffEq]
 ```
+
 ## Need Documentation  
 DiscreteUDE
 MultiUDE

--- a/docs/src/BayesianModels.md
+++ b/docs/src/BayesianModels.md
@@ -60,14 +60,6 @@ plot_predictions(UDE::BayesianUDE;ci=95)
 ```
 
 ```@docs; canonical=false
-forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{};summarize = true, ci = 95)
-```
-
-```@docs; canonical=false
-forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{};summarize = true, ci = 95)
-```
-
-```@docs; canonical=false
 plot_forecast(UDE::BayesianUDE, T::Int;ci = 95)
 ```
 

--- a/docs/src/BayesianModels.md
+++ b/docs/src/BayesianModels.md
@@ -3,7 +3,7 @@
 UniversalDiffEq.jl provides training algorithms for uncertainty quantification in NODEs and UDEs using [Bayesian NODEs and UDEs](https://arxiv.org/abs/2012.07244). UniversalDiffEq.jl currently supports the classical No-U-Turn Sampling (NUTS) and the [Stochastic Gradient Langevin Dynamics](https://www.stats.ox.ac.uk/~teh/research/compstats/WelTeh2011a.pdf) (SGLD) algorithms. These algorithms are available for the `BayesianUDE` constructor. This constructor can be created using the `BayesianNODE` and `BayesianCustomDerivatives` functions. These functions follow the same structure as their non-Bayesian versions `NODE` and `CustomDerivatives`.
 
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.BayesianNODE(data;kwargs ... )
 UniversalDiffEq.BayesianNODE(data,X;kwargs ... )
 UniversalDiffEq.BayesianCustomDerivatives(data::DataFrame,derivs!::Function,initial_parameters;kwargs ... )
@@ -44,33 +44,33 @@ Training is then done using `NUTS!` or `SGLD!`:
 NUTS!(model,samples = 500)
 ```
 
-```@docs
+```@docs; canonical=false
 NUTS!(UDE::BayesianUDE;kwargs ...)
 SGLD!(UDE::BayesianUDE;kwargs ...)
 ```
 
 The other functions for [model analysis](modelanalysis.md) have methods for the `BayesianUDE` constructor:
 
-```@docs
+```@docs; canonical=false
 predict(UDE::BayesianUDE,test_data::DataFrame;summarize = true,ci = 95,df = true)
 ```
 
-```@docs
+```@docs; canonical=false
 plot_predictions(UDE::BayesianUDE;ci=95)
 ```
 
-```@docs
+```@docs; canonical=false
 forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{};summarize = true, ci = 95)
 ```
 
-```@docs
+```@docs; canonical=false
 forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{};summarize = true, ci = 95)
 ```
 
-```@docs
+```@docs; canonical=false
 plot_forecast(UDE::BayesianUDE, T::Int;ci = 95)
 ```
 
-```@docs
+```@docs; canonical=false
 plot_forecast(UDE::BayesianUDE, test_data::DataFrame;ci = 95)
 ```

--- a/docs/src/EasyModels.md
+++ b/docs/src/EasyModels.md
@@ -4,7 +4,7 @@
 
 # EasyNODE constructors:
 
-```@docs
+```@docs; canonical=false
 EasyNODE(data,X;kwargs ... )
 EasyNODE(data;kwargs ... )
 ```
@@ -21,7 +21,7 @@ gradient_descent!(model)
 
 # EasyUDE constructors:
 
-```@docs
+```@docs; canonical=false
 EasyUDE(data,known_dynamics!,initial_parameters;kwargs ... )
 EasyUDE(data::DataFrame,X,known_dynamics!::Function,initial_parameters;kwargs ... )
 ```

--- a/docs/src/ModelTesting.md
+++ b/docs/src/ModelTesting.md
@@ -6,20 +6,20 @@ UniversalDiffEq.jl provides a number of functions to test the performance of NOD
 
 There are two primary functions to test model fits: `plot_state_estimates` and `plot_predictions`. The model fitting procedure estimates the value of the state variables ``\hat{u}`` at each time point in the data set as well as the parameters of the NODE or UDE model that predicts changes in the state variables. The `plot_state_estimates` function compares the estimated states to the data to check the quality of the state estimates, and `plot_predictions` compares the predictions of UDE model one step into the future to the estimated sequence of state variables. Both functions take a UDE as an input and return a plot showing the correspondence between model predictions and observations. 
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.plot_state_estimates(UDE::UDE)
 UniversalDiffEq.plot_predictions(UDE::UDE)
 ```
 
 There are also functions to compare the model predictions to out-of-sample data. The simplest is `plot_forecast`, which compares the observations in the test data set to a deterministic simulation from the data set, which starts at the first observation and runs to the end of the test data. 
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.plot_forecast(UDE::UDE, test_data::DataFrame)
 ```
 
 It is also possible to test the performance of the models one time step into the future using the `plot_predictions` function. When a test data set is supplied to the `plot_predictions` function, it will run a series of forecasts starting at each point in the data set, predicting one time step into the future. The function returns a plot comparing the predicted and observed changes.
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.plot_predictions(UDE::UDE, test_data::DataFrame)
 ```
 
@@ -28,7 +28,7 @@ UniversalDiffEq.plot_predictions(UDE::UDE, test_data::DataFrame)
 Cross-validation is important for model comparison and hyper-parameter tuning. The `leave_future_out_cv` function breaks the data set into training and test data sets by leaving off the final observations in the data set. The model is then trained on the beginning of the data set and the performance is calculated by comparing a forecast to the test data. The user can specify the time horizon for the forecast ``T_{Forecast}`` and the number of tests ``K``. The first test trains the model on the full data set only omitting the final ``T_{forecast}`` years as the test set. The remaining tests each generate a new test data set by iteratively removing more of the observations from the end of the data set. The number removed between each test can be controlled by changing the spacing argument. The `kfold_cv` function performs a k-fold version of `leave_future_out_cv`.
 
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.leave_future_out_cv(model::UDE)
 UniversalDiffEq.kfold_cv(model::UDE)
 ```

--- a/docs/src/Models.md
+++ b/docs/src/Models.md
@@ -62,7 +62,7 @@ Covariates can be added to the model by supplying a second data frame `X`. This 
 ```
 The values of the covariates between time points included in the data frame `X` are interpolated using a linear spline.  
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.NODE(data,X;kwargs ... )
 ```
 

--- a/docs/src/Models.md
+++ b/docs/src/Models.md
@@ -49,7 +49,7 @@ and NNDEs use a neural network as the right-hand side of a difference equation
 
 The `NODE` and `NNDE` functions construct each model type.
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.NODE(data;kwargs ... )
 UniversalDiffEq.NNDE(data;kwargs ...)
 ```
@@ -73,7 +73,7 @@ The `CustomDerivatives` and `CustomDifference` functions can be used to build mo
 
 The `CustomDerivatives` function builds UDE models based on a user-defined function `derivs!(du,u,p,t)`, which updates the vector `du` with the right-hand side of a differential equation evaluated at time `t` in state `u` given parameters `p`. The function also needs an initial guess at the model parameters, specified by a NamedTuple `initial_parameters`
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.CustomDerivatives(data,derivs!,initial_parameters;kwargs ... )
 ```
 
@@ -125,19 +125,19 @@ model = CustomDerivatives(data,lotka_volterra_derivs!,initial_parameters)
 
 Discrete time models are constructed in a similar way to continuous time models. The user provides the right-hand side of a difference equation with the function `step` and initial parameters. The function `step(u,t,p)` takes three arguments: the value of the state variables `u`, time `t`, and model parameters `p`.
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.CustomDifference(data,step,initial_parameters;kwrags...)
 ```
 
 ## Adding covariates
 
 Covariates can also be added to UDE models by passing a data frame `X` and adding covariates as an argument to the `derivs!` function which has the new form `derivs!(du,u,X,p,t)`, where the third argument `X` is a vector of covariates. 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.CustomDerivatives(data::DataFrame,X,derivs!::Function,initial_parameters;kwargs ... )
 ```
 
 Covariates can also be added to a discrete time framework in the same way. The `step` function should have four arguments `step(u,X,t,p)`.
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.CustomDifference(data::DataFrame,X,step,initial_parameters;kwargs ... )
 ```
 ### Example
@@ -180,7 +180,7 @@ If you wish to build a model with covariates that are measured at different poin
 
 ## Adding prior information to custom models 
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.CustomDerivatives(data::DataFrame,derivs!::Function,initial_parameters,priors::Function;kwargs ... )
 UniversalDiffEq.CustomDifference(data::DataFrame,step,initial_parameters,priors::Function;kwargs ... )
 ```

--- a/docs/src/MultipleTimeSeries.md
+++ b/docs/src/MultipleTimeSeries.md
@@ -13,7 +13,7 @@ UniversalDiffEq.jl provides a set of functions to fit models to multiple time se
 |3  | 2      | ``x_{2,1,t}`` | ``x_{2,2,t}``  |
 
 Covariates can be added to the models as well. The covariates data frame must have the same structure. 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.MultiNODE(data;kwargs...)
 UniversalDiffEq.MultiNODE(data,X;kwargs...)
 ```

--- a/docs/src/NutsAndBolts.md
+++ b/docs/src/NutsAndBolts.md
@@ -29,19 +29,19 @@ L(u,\theta_{proc},\theta_{obs};x) = \sum_{t =1}^{T} L_{obs}(x_t,h(u_t,\theta_{ob
 where the ``\sigma_i`` are parameters for the loss functions and the ``\theta_i`` are parameters for the prediction functions. 
 
 The UDE object combines the observation and process models and their respective loss and regularization models into one larger model object along with the data used to fit the model.
-```@docs
+```@docs; canonical=false
 UDE
 ```
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.ProcessModel
 ```
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.LossFunction
 ```
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.Regularization  
 ```
 

--- a/docs/src/ODEAnalysis.md
+++ b/docs/src/ODEAnalysis.md
@@ -1,6 +1,6 @@
 # Analyzing fitted models
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.equilibrium_and_stability(UDE,lower,upper;t=0,Ntrials=100,tol=10^-3)
 UniversalDiffEq.equilibrium_and_stability(UDE,X,lower,upper;t=0,Ntrials=100,tol=10^-3)
 UniversalDiffEq.equilibrium_and_stability(UDE::MultiUDE,site,X,lower,upper;t=0,Ntrials=100,tol=10^-3)

--- a/docs/src/modelanalysis.md
+++ b/docs/src/modelanalysis.md
@@ -2,7 +2,7 @@
 
 UniversalDiffEq.jl provides several functions to analyze the characteristics of the fitted models. The most basic of these is the `get_right_hand_side` function. This function takes a UDE model as an argument and returns the right-hand side of the fitted differential or difference equation. This function can then be treated like any dynamic model and analyzed for equilibria, stability, tipping points, and other phenomena of interest.  
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.get_right_hand_side(UDE::UDE)
 ```
 
@@ -10,13 +10,13 @@ The library also has functions to evaluate model predictions. The `forecast` fun
 
 
 The function `phase_plane` plots forecasted trajectories of state variables for a given number of timesteps `T`. All phase plane functions also work with the `MultiUDE` model type, and plot phase planes for each series in the data.
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.phase_plane(UDE::UDE; idx=[1,2], u1s=-5.0,0.25,5.0, u2s=-5:0.25:5,u3s = 0,T = 100)
 UniversalDiffEq.phase_plane(UDE::UDE, u0s::AbstractArray; idx=[1,2],T = 100)
 UniversalDiffEq.phase_plane_3d(UDE::UDE; idx=[1,2,3], u1s=-5.0,0.25,5.0, u2s=-5:0.25:5,u3s=-5:0.25:5,T = 100)
 ```
 
-```@docs
+```@docs; canonical=false
 UniversalDiffEq.forecast(UDE::UDE, u0::AbstractVector, times::AbstractVector)
 UniversalDiffEq.print_parameter_estimates(UDE::UDE)
 UniversalDiffEq.plot_forecast(UDE::UDE, T::Int)

--- a/src/ModelTesting.jl
+++ b/src/ModelTesting.jl
@@ -224,7 +224,7 @@ function predict(UDE::UDE,test_data::DataFrame;df = true)
 end 
 
 """
-predict(UDE::BayesianUDE,test_data::DataFrame;summarize = true,ci = 95,df = true)
+    predict(UDE::BayesianUDE,test_data::DataFrame;summarize = true,ci = 95,df = true)
 
 Uses the Bayesian UDE `UDE` to predict the state of the data `test_data` for each of the sampled parameters in training. 
 
@@ -294,7 +294,6 @@ end
 Plots the correspondence between the observed state transitons and the predicitons for the model `UDE` with a confidence interval `ci`. 
 
 """
-
 function plot_predictions(UDE::BayesianUDE;ci=95)
  
     inits, obs, preds = predictions(UDE,summarize = true,ci=ci)
@@ -491,7 +490,7 @@ end
 
 
 """
-    forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real;summarize = true, ci = 95)
+    forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{};summarize = true, ci = 95)
 
 predictions from the trained model `UDE` starting at `u0` saving values at `times` at each individual sampled parameter. Assumes `u0` occurs at time `t0` and `times` are all larger than `t0`.
 

--- a/src/ModelTesting.jl
+++ b/src/ModelTesting.jl
@@ -413,13 +413,13 @@ function forecast(UDE::UDE, u0::AbstractVector{}, times::AbstractVector{})
 end 
 
 """
-    forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{};summarize = true, ci = 95)
+    forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{}; summarize = true, ci = 95)
 
 predictions from the trained model `UDE` starting at `u0` saving values at `times` at each individual sampled parameter. Assumes `u0` is the value at time `times[1]`
 
 If `summarize` is `true`, this function returns the median prediction as well as the `ci`% lower and upper confidence intervals. Othwerise, it returns all the individual predictions for each sampled parameter.
 """
-function forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{};summarize = true, ci = 95)
+function forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{}; summarize = true, ci = 95)
     dfs = zeros(length(UDE.parameters),length(times),length(x)+1)
 
     for i in 1:length(UDE.parameters)
@@ -453,7 +453,7 @@ function forecast(UDE::BayesianUDE, u0::AbstractVector{}, times::AbstractVector{
 end 
 
  """
-     forecast(UDE::UDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{})
+    forecast(UDE::UDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{})
 
  predictions from the trained model `UDE` starting at `u0` saving values at `times`. Assumes `u0` occurs at time `t0` and `times` are all larger than `t0`.
  """
@@ -490,7 +490,7 @@ end
 
 
 """
-    forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{};summarize = true, ci = 95)
+    forecast(UDE::BayesianUDE, u0::AbstractVector{}, t0::Real, times::AbstractVector{}; summarize = true, ci = 95)
 
 predictions from the trained model `UDE` starting at `u0` saving values at `times` at each individual sampled parameter. Assumes `u0` occurs at time `t0` and `times` are all larger than `t0`.
 


### PR DESCRIPTION
autodocs block in API page should automatically include every docstring created in package and list it.

To avoid getting errors from referencing docstrings multiple times, all other docs blocks must not be canonical